### PR TITLE
Drivers: implement one-wire wire driver for temperature sensors

### DIFF
--- a/examples/.cargo/config.toml
+++ b/examples/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "probe-rs run --chip STM32G474RBTx"
+
+[build]
+target = "thumbv7em-none-eabihf"
+
+[env]
+DEFMT_LOG = "trace"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "exo-examples"
+version = "0.1.0"
+edition = "2024"
+license = "GPL-v3"
+
+[dependencies]
+embassy-stm32 = { version = "0.2.0", features = [ "defmt", "time-driver-any", "stm32g474rb", "memory-x", "unstable-pac", "exti"]  }
+embassy-sync = { version = "0.7.0", features = ["defmt"] }
+embassy-executor = { version = "0.7.0", features = ["arch-cortex-m", "executor-thread", "defmt"] }
+embassy-time = { version = "0.4.0", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-100_000_000"] }
+embassy-usb = { version = "0.4.0", features = ["defmt"] }
+embassy-futures = { version = "0.1.0" }
+usbd-hid = "0.8.1"
+
+defmt = "1.0.1"
+defmt-rtt = "1.0.0"
+
+cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
+cortex-m-rt = "0.7.0"
+embedded-hal = "0.2.6"
+embedded-can = { version = "0.4" }
+panic-probe = { version = "1.0.0", features = ["print-defmt"] }
+heapless = { version = "0.8", default-features = false }
+static_cell = "2.0.0"
+
+exo-drivers = { path = "../exo-drivers/" }
+
+[profile.release]
+debug = 2

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("cargo:rustc-link-arg-bins=-nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/examples/src/bin/ds18b20.rs
+++ b/examples/src/bin/ds18b20.rs
@@ -1,0 +1,61 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use embassy_executor::Spawner;
+use embassy_stm32::Config;
+use embassy_time::Timer;
+use exo_drivers::{
+    ds18b20::{self, DS18B20},
+    one_wire_bus::OneWireBus,
+};
+use {defmt_rtt as _, panic_probe as _};
+
+fn get_device_config() -> Config {
+    let mut config = Config::default();
+
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.hsi = true;
+        config.rcc.pll = Some(Pll {
+            source: PllSource::HSI,
+            prediv: PllPreDiv::DIV2,
+            mul: PllMul::MUL25,
+            divp: None,
+            divq: None,
+            divr: Some(PllRDiv::DIV2),
+        });
+        config.rcc.sys = Sysclk::PLL1_R;
+    }
+
+    config
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init(get_device_config());
+
+    let mut bus = OneWireBus::init(p.PC3);
+
+    let address = bus.read_rom().await.unwrap();
+    info!("Device with address: 0x{:014x} found!", address);
+
+    // Create a device with no address: must be the only device on the bus
+    let mut sensor = DS18B20::new(None);
+
+    sensor
+        .ensure_config(
+            &mut bus,
+            ds18b20::Config::new(ds18b20::Resolution::NineBits),
+        )
+        .await
+        .unwrap();
+
+    loop {
+        match sensor.read_temperature(&mut bus).await {
+            Err(e) => info!("Failed to read temperature: {}", e),
+            Ok(temperature) => info!("Temperature: {} C", temperature),
+        }
+        //Timer::after_millis(1000).await;
+    }
+}

--- a/exo-drivers/.cargo/config.toml
+++ b/exo-drivers/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+runner = "probe-rs run --chip STM32G474RBTx"
+
+[build]
+target = "thumbv7em-none-eabihf"
+
+[env]
+DEFMT_LOG = "trace"

--- a/exo-drivers/Cargo.toml
+++ b/exo-drivers/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "exo-drivers"
+version = "0.1.0"
+edition = "2024"
+license = "GPL-v3"
+
+[dependencies]
+embassy-stm32 = { version = "0.2.0", features = [ "defmt", "time-driver-any", "stm32g474rb", "unstable-pac", "exti"]  }
+embassy-time = { version = "0.4.0", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-100_000_000"] }
+
+defmt = "1.0.1"
+defmt-rtt = "1.0.0"
+
+embedded-hal = "0.2.6"
+embedded-can = { version = "0.4" }
+panic-probe = { version = "1.0.0", features = ["print-defmt"] }
+static_cell = "2.0.0"
+
+crc = "3.3.0"
+
+[profile.release]
+debug = 2

--- a/exo-drivers/src/ds18b20.rs
+++ b/exo-drivers/src/ds18b20.rs
@@ -1,0 +1,216 @@
+//! # Description
+//! Ds18b20 device driver to use with a 1-wire bus.
+//!
+//! See [`crate::one_wire_bus`] for important clock configuration details.
+//!
+//! # Examples
+//! ## 1. Getting the address of a connected device
+//! Use this if you need to determine the ROM code (address of a sensor). For the follwing example 
+//! to work, only one sensor must be connected on the bus. Reading the address from multiple
+//! devices on the same board has not been implemented.
+//! ```
+//! let p = embassy_stm32::init(get_device_config())
+//!
+//! let mut bus = OneWireBus::init(p.PC3);
+//!
+//! match bus.read_rom() {
+//!     Err(e) => info!("Error reading sensor value: {}", e),
+//!     Ok(addr) => info!("Found sensor with address {:x}", addr),
+//! }
+//! ```
+//! It is not recommended to fetch the address of the device at the start of the program. Instead,
+//! it should be noted down and added directly into the code (either hard-coded or with a
+//! compile-time configuration). Addresses are only useful when multiple devices are sensors are
+//! connected on the same bus. See second example below.
+//!
+//! ## 2. Reading the temperature from a sensor
+//! In the following example, we initialize the bus and the sensor, configure the sensor and read
+//! the temperature roughly every second (since the conversion time increases the delay in each
+//! iteration).
+//! ```
+//! let p = embassy_stm32::init(get_device_config());
+//!
+//! let mut bus = OneWireBus::init(p.PC3);
+//! let mut sensor = DS18B20::new(None);
+//! sensor.ensure_config(&mut bus, ds18b20::Config::new(ds18b20::Resolution::NineBits)).unwrap();
+//!
+//! loop {
+//!     match sensor.read_temperature(&mut bus).await {
+//!         Err(e) => info!("Failed to read temperature: {}", e),
+//!         Ok(temperature) => info!("Temperature: {} C", temperature),
+//!     }
+//!     Timer::after_millis(1000).await;
+//! }
+//! ```
+//! Here, it is assumed that there is only one 1-wire device on the bus. Therefore, the address
+//! given to the temperature sensor is `None`. If more than one device shared the 1-wire bus,
+//! multiple sensors objects must be created, each with their address passed as argument to `new`
+//! (instead of `None`). The address does not need to include the CRC-8 code.
+
+use crc::CRC_8_MAXIM_DOW;
+use embassy_time::Timer;
+
+use crate::one_wire_bus::{self, OneWireBus};
+
+const BASE_CONFIGURATION_REG: u8 = 0x1F; // see docs
+const CONFIG_RESOLUTION_BITSHIFT: u8 = 5;
+
+const NINE_BITS_CONVERSION_DELAY_MS: u64 = 100;
+const TEN_BITS_CONVERSION_DELAY_MS: u64 = 200;
+const ELEVEN_BITS_CONVERSION_DELAY_MS: u64 = 400;
+const TWELVE_BITS_CONVERSION_DELAY_MS: u64 = 800;
+
+#[repr(u8)]
+enum FunctionCommands {
+    Convert = 0x44,
+    WriteScratchpad = 0x4E,
+    ReadScratchpad = 0xBE,
+    CopyScratchpad = 0x48,
+    RecallEEPROM = 0xB8,
+}
+
+#[derive(Clone, Copy)]
+pub enum Resolution {
+    NineBits = 0b00,
+    TenBits = 0b01,
+    ElevenBits = 0b10,
+    TwelveBits = 0b11,
+}
+
+pub struct Config {
+    pub resolution: Resolution,
+}
+
+impl Config {
+    pub fn new(resolution: Resolution) -> Self {
+        Self { resolution }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            resolution: Resolution::NineBits,
+        }
+    }
+}
+
+#[derive(Debug, defmt::Format)]
+pub enum Error {
+    InvalidCrc,
+    BusError(one_wire_bus::Error),
+    UnexpectedReservedValue,
+}
+
+impl From<one_wire_bus::Error> for Error {
+    fn from(value: one_wire_bus::Error) -> Self {
+        Self::BusError(value)
+    }
+}
+
+pub struct DS18B20 {
+    address: Option<u64>,
+    config: Option<Config>,
+}
+
+impl DS18B20 {
+    /// Create a new DS18B20 device with a given address.
+    /// > **Note**: set address to None if _and only if_ there is no other device on the 1-wire
+    /// > bus.
+    pub fn new(address: Option<u64>) -> Self {
+        Self {
+            address,
+            config: None,
+       }
+    }
+
+    async fn read_scratchpad(&mut self, bus: &mut OneWireBus) -> Result<(f32, [u8; 3]), Error> {
+        let mut scratchpad_data = [0; 9];
+        bus.send_command_read(
+            FunctionCommands::ReadScratchpad as u8,
+            self.address,
+            &mut scratchpad_data,
+        ).await?;
+
+        // see datasheet
+        if scratchpad_data[5] != 0xFF || scratchpad_data[7] != 0x10 {
+            return Err(Error::UnexpectedReservedValue);
+        }
+
+        let calculated_crc = crc::Crc::<u8>::new(&CRC_8_MAXIM_DOW).checksum(&scratchpad_data[..8]);
+
+        if scratchpad_data[8] != calculated_crc {
+            return Err(Error::InvalidCrc);
+        }
+
+        // bit-shift manipulations could change the sign of the value, therefore we manipulate
+        // unsigned values first
+        let temperature = (scratchpad_data[0] as u16) | ((scratchpad_data[1] as u16) << 8);
+        // then we can take the sign into account
+        let temperature = temperature as i16;
+        // Convert fixed-point value (as i16) to floating point. Notes:
+        // 1. We ignore the fact that the last bits are undefined for precisions below 12bits. This
+        //    is fine since they only cause small variations in the output.
+        // 2. The value 16.0 comes from the fact that the decimal point is between the 3rd and 4th
+        //    bit (2 ^ 4 = 16).
+        let temperature = (temperature as f32) / 16.0;
+
+        // unwrap: we hard-code the slice to be 3-byte long, and the scratch_pad data array is
+        // 9 bits long.
+        let configuration_bytes = scratchpad_data[2..=4].try_into().unwrap();
+
+        Ok((temperature, configuration_bytes))
+    }
+
+    /// Write the given configuration on the RAM and persistent memories of the sensor.
+    /// Will not write or change the memory if the correct configuration is already loaded.
+    pub async fn ensure_config(&mut self, bus: &mut OneWireBus, config: Config) -> Result<(), Error> {
+        bus.send_command(FunctionCommands::RecallEEPROM as u8, self.address).await?;
+
+        let config_byte =
+            BASE_CONFIGURATION_REG | ((config.resolution as u8) << CONFIG_RESOLUTION_BITSHIFT);
+        let expected_data = [0xFF, 0x00, config_byte];
+
+        let scratchpad_data = self.read_scratchpad(bus).await?;
+
+        if scratchpad_data.1 == expected_data {
+            self.config = Some(config);
+            return Ok(());
+        }
+
+        bus.send_command_with_data(
+            FunctionCommands::WriteScratchpad as u8,
+            self.address,
+            &expected_data,
+        ).await?;
+        bus.send_command(FunctionCommands::CopyScratchpad as u8, self.address).await?;
+
+        self.config = Some(config);
+
+        Ok(())
+    }
+
+    /// Get the temperature from the sensor, which takes a varying amount of time depending on the
+    /// precision required in the config. The function is async to allow other tasks to execute
+    /// while the temperature is being measured and converted on the sensor.
+    ///
+    /// **Important**: make sure the configuration is set by calling [`Self::ensure_config`] before
+    /// calling this method.
+    pub async fn read_temperature(&mut self, bus: &mut OneWireBus) -> Result<f32, Error> {
+        bus.send_command(FunctionCommands::Convert as u8, self.address).await?;
+        let config = self.config.as_ref().expect("Configuration should be set using `DS18B20::ensure_config(...)` before reading temperature");
+
+        let delay = match config.resolution {
+            Resolution::NineBits => NINE_BITS_CONVERSION_DELAY_MS,
+            Resolution::TenBits => TEN_BITS_CONVERSION_DELAY_MS,
+            Resolution::ElevenBits => ELEVEN_BITS_CONVERSION_DELAY_MS,
+            Resolution::TwelveBits => TWELVE_BITS_CONVERSION_DELAY_MS,
+        };
+
+        Timer::after_millis(delay).await;
+
+        let (temperature, _) = self.read_scratchpad(bus).await?;
+
+        Ok(temperature)
+    }
+}

--- a/exo-drivers/src/lib.rs
+++ b/exo-drivers/src/lib.rs
@@ -1,3 +1,4 @@
 #![no_std]
 
 pub mod one_wire_bus;
+pub mod ds18b20;

--- a/exo-drivers/src/lib.rs
+++ b/exo-drivers/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+pub mod one_wire_bus;

--- a/exo-drivers/src/one_wire_bus.rs
+++ b/exo-drivers/src/one_wire_bus.rs
@@ -9,6 +9,9 @@
 //! - [DS18B20 datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/DS18B20.pdf)
 //! - [Book of iButton(r) Standards](https://www.analog.com/media/en/technical-documentation/tech-articles/book-of-ibuttonreg-standards.pdf)
 //! - [Interfacing the DS18X20/DS1822 1-Wire(r) Temperature Sensor in a Microcontroller Environment ](https://www.analog.com/en/resources/technical-articles/interfacing-the-ds18x20ds1822-1wire-temperature-sensor-in-a-microcontroller-environment.html)
+//!
+//! # Example
+//! See [`crate::ds18b20`]
 
 use core::result::Result::*;
 

--- a/exo-drivers/src/one_wire_bus.rs
+++ b/exo-drivers/src/one_wire_bus.rs
@@ -1,0 +1,238 @@
+//! # Description
+//! 1-Wire bus on which one or more sensors can be connected
+//!
+//! > **Note**: The protocol was implemented by bit-banging. Therefore, it is required that the
+//! > system and GPIO peripheral clocks have a good enough resolution (some delays are as small as
+//! > 1us). A clock speed of 100 MHz is a good value.
+//!
+//! # References:
+//! - [DS18B20 datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/DS18B20.pdf)
+//! - [Book of iButton(r) Standards](https://www.analog.com/media/en/technical-documentation/tech-articles/book-of-ibuttonreg-standards.pdf)
+//! - [Interfacing the DS18X20/DS1822 1-Wire(r) Temperature Sensor in a Microcontroller Environment ](https://www.analog.com/en/resources/technical-articles/interfacing-the-ds18x20ds1822-1wire-temperature-sensor-in-a-microcontroller-environment.html)
+
+use core::result::Result::*;
+
+use crc::CRC_8_MAXIM_DOW;
+
+use embassy_stm32::{
+    Peripheral,
+    gpio::{Flex, Pin, Speed},
+};
+
+use embassy_time::{block_for, Duration, Instant, Timer};
+
+/// t_RSTL
+const RESET_LOW_DURATION: Duration = Duration::from_micros(480);
+/// t_RSTH
+const RESET_HIGH_DURATION: Duration = Duration::from_micros(480);
+/// t_LOW0
+const WRITE_ZERO_PULSE_DURATION: Duration = Duration::from_micros(60);
+/// t_LOW1
+const WRITE_ONE_PULSE_DURATION: Duration = Duration::from_micros(15);
+/// t_REC
+const RECOVERY_DURATION: Duration = Duration::from_micros(2);
+/// t_SLOT
+const SLOT_DURATION: Duration = Duration::from_micros(60);
+/// duration of low pulse to tell the sensors the leader is ready to read
+const READ_INIT_PULSE_DURATION: Duration = Duration::from_micros(2);
+/// t_RDV
+const READ_DATA_VALID_DURATION: Duration = Duration::from_micros(11);
+
+/// 1-wire bus handle
+pub struct OneWireBus {
+    gpio: Flex<'static>,
+}
+
+/// Possible 1-wire ROM commands (network layer)
+#[repr(u8)]
+enum RomCommand {
+    ReadRom = 0x33,
+    MatchRom = 0x55,
+    SkipRom = 0xCC,
+}
+
+/// possible 1-wire bus errors
+#[derive(Debug, defmt::Format)]
+pub enum Error {
+    NoDeviceOnReset,
+    NoDeviceOnSearch,
+    TooManyDevices,
+    NotEnoughDevices,
+    InvalidCrc,
+}
+
+impl OneWireBus {
+    /// Create a new 1-wire bus handle
+    pub fn init(pin: impl Peripheral<P = impl Pin> + 'static) -> Self {
+        let mut gpio = Flex::new(pin);
+        gpio.set_as_input_output(Speed::Low);
+
+        Self { gpio }
+    }
+
+    /// Send a reset pulse and check if a device responds
+    async fn reset_and_detect(&mut self) -> Result<(), Error> {
+        // Send reset pulse
+        self.gpio.set_low();
+        Timer::after(RESET_LOW_DURATION).await;
+        self.gpio.set_high();
+
+        // Wait until end of reset sequence
+        let reset_end_instant = Instant::now() + RESET_HIGH_DURATION;
+        let mut is_found = false;
+        while Instant::now() < reset_end_instant {
+            // Check if there is a sensor connected on the bus.
+            // According to the datasheet, this should happen within 15 to 300 ms
+            // after the end of the reset pulse, but we'll ignore timing here since
+            // it doesn't really matter.
+            if !is_found && self.gpio.is_low() {
+                is_found = true;
+            }
+
+            // The loop will last for `RESET_HIGH_DURATION` no matter if a sensor
+            // is found or not.
+        }
+
+        if is_found {
+            Ok(())
+        } else {
+            Err(Error::NoDeviceOnReset)
+        }
+    }
+
+    /// Write a single bit on the bus
+    async fn write_bit(&mut self, value: bool) -> () {
+        self.gpio.set_low();
+        let write_end_instant = Instant::now() + SLOT_DURATION;
+
+        if value {
+            block_for(WRITE_ONE_PULSE_DURATION);
+        } else {
+            block_for(WRITE_ZERO_PULSE_DURATION);
+        }
+
+        self.gpio.set_high();
+
+        while Instant::now() < write_end_instant {}
+
+        Timer::after(RECOVERY_DURATION).await;
+    }
+
+    /// Read a single bit from the bus.
+    /// Note: a value of 1 (true) could also mean no sensor is connected
+    async fn read_bit(&mut self) -> bool {
+        // Read trigger pulse
+        self.gpio.set_low();
+        let read_end_instant = Instant::now() + SLOT_DURATION;
+        block_for(READ_INIT_PULSE_DURATION);
+        self.gpio.set_high();
+
+        block_for(READ_DATA_VALID_DURATION - READ_INIT_PULSE_DURATION);
+        let value = self.gpio.is_high();
+
+        while Instant::now() < read_end_instant {}
+
+        Timer::after(RECOVERY_DURATION).await;
+
+        value
+    }
+
+    /// Write a byte on the 1-wire bus
+    async fn write_byte(&mut self, byte: u8) -> () {
+        for i in 0..8 {
+            self.write_bit((byte >> i) & 0x01 == 0x01).await;
+        }
+    }
+
+    /// Read a byte from the 1-wire bus
+    async fn read_byte(&mut self) -> u8 {
+        let mut data: u8 = 0;
+        for i in 0..8 {
+            data |= (self.read_bit().await as u8) << i;
+        }
+
+        data
+    }
+
+    /// Transmit a rom command on the bus
+    async fn send_rom_command(&mut self, command: RomCommand) -> () {
+        self.write_byte(command as u8).await;
+    }
+
+    /// Fetch the address from a 1-wire device. IMPORTANT: there must be only one device on the
+    /// bus.
+    pub async fn read_rom(&mut self) -> Result<u64, Error> {
+        self.reset_and_detect().await?;
+        self.send_rom_command(RomCommand::ReadRom).await;
+
+        // the first 7 bytes make up the address
+        let mut address: u64 = 0;
+        for i in 0..7 {
+            let data = self.read_byte().await;
+            address |= (data as u64) << (i * 8);
+        }
+
+        // and the last byte is the crc-8 code
+        let received_crc = self.read_byte().await;
+        let calculated_crc =
+            crc::Crc::<u8>::new(&CRC_8_MAXIM_DOW).checksum(&address.to_le_bytes()[..7]);
+        if received_crc != calculated_crc {
+            return Err(Error::InvalidCrc);
+        }
+
+        Ok(address)
+    }
+
+    /// Send a function command
+    pub async fn send_command(&mut self, command: u8, address: Option<u64>) -> Result<(), Error> {
+        self.reset_and_detect().await?;
+        if let Some(address) = address {
+            self.send_rom_command(RomCommand::MatchRom).await;
+            for i in 0..7 {
+                self.write_byte(((address >> (i * 8)) & 0xFF) as u8).await;
+            }
+
+            self.write_byte(
+                crc::Crc::<u8>::new(&CRC_8_MAXIM_DOW).checksum(&address.to_le_bytes()[..7]),
+            ).await;
+        } else {
+            self.send_rom_command(RomCommand::SkipRom).await;
+        }
+
+        self.write_byte(command).await;
+
+        Ok(())
+    }
+
+    /// Send a function command, followed by data bytes
+    pub async fn send_command_with_data(
+        &mut self,
+        command: u8,
+        address: Option<u64>,
+        data: &[u8],
+    ) -> Result<(), Error> {
+        self.send_command(command, address).await?;
+
+        for byte in data {
+            self.write_byte(*byte).await;
+        }
+
+        Ok(())
+    }
+
+    /// Send a function command and read bytes from device
+    pub async fn send_command_read(
+        &mut self,
+        command: u8,
+        address: Option<u64>,
+        out_data: &mut [u8],
+    ) -> Result<(), Error> {
+        self.send_command(command, address).await?;
+
+        for i in 0..out_data.len() {
+            out_data[i] = self.read_byte().await;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Driver implementation for the DS18B20 temperature sensor using the one-wire protocol.

Not all functionalities of the sensor are supported. In particular, the search commands (alarm search and search rom) are not implemented. Also, the read power supply command is not used since we will always connect an external power supply.